### PR TITLE
Update terragrunt.hcl

### DIFF
--- a/dry-configurations/production/ec2/terragrunt.hcl
+++ b/dry-configurations/production/ec2/terragrunt.hcl
@@ -1,6 +1,6 @@
 # Use remote module for configuration
 terraform {
-  source = "git::github.com/cloudacademy/terraform-aws-calabmodules.git//ec2?ref=v0.0.2"
+  source = "git::github.com/cloudacademy/terraform-aws-calabmodules.git//ec2?ref=0.0.3"
 }
 
 # Pass data into remote module with inputs


### PR DESCRIPTION
Referring to the new tag release to avoid using the v0.0.2 that still uses the t3.nano instance type (it causes the user's ban).